### PR TITLE
add fix vcf header script

### DIFF
--- a/bin/fix_vcf_header.sh
+++ b/bin/fix_vcf_header.sh
@@ -1,0 +1,108 @@
+VCF=$1
+VCF_OUTPUT=$2
+THREADS=$3
+BCFTOOLS=$4
+REFORMAT=$5
+
+# input
+if [ -z "$VCF" ]; then
+    echo "#[ERROR] No VCF input"
+    exit 1
+fi;
+
+# output
+if [ -z "$VCF_OUTPUT" ]; then
+    VCF_OUTPUT=$VCF
+fi;
+
+# threads
+if [ -z "$THREADS" ]; then
+    THREADS=1
+fi;
+
+# bcftools
+if [ -z "$BCFTOOLS" ]; then
+    BCFTOOLS=bcftools
+fi;
+
+# reformat
+if [ -z "$REFORMAT" ]; then
+    REFORMAT=0
+fi;
+
+# Extension
+EXTENSION="${VCF_OUTPUT##*.}"
+
+
+# tmp
+OUTPUT_TMP=$VCF.tmp.$RANDOM
+
+# Header with comma in Description
+$BCFTOOLS view --threads=$THREADS -h $VCF | awk '
+BEGIN {
+    sep=""    # alternative separator 
+}
+{
+    # header line with comma in Description
+    if ( ($0 ~ /^##INFO/ || $0 ~ /^##FORMAT/ || $0 ~ /^##FILTER/) && $0 ~ /Description=\".*,.*\"/ ) {
+        match($0, /^(.*)(Description=\".*\")(.*)$/, arr);
+        gsub(",",sep,arr[2]);
+        print arr[1] arr[2] arr[3]
+    # other lines
+    } else {
+        print $0
+    }
+}' > $OUTPUT_TMP.header
+
+# reheader
+$BCFTOOLS reheader --threads=$THREADS -h $OUTPUT_TMP.header $VCF > $OUTPUT_TMP;
+
+# Reformat
+if (($REFORMAT)); then
+
+    # Find error in bcftools
+    $BCFTOOLS view -h $OUTPUT_TMP 1>/dev/null 2>$OUTPUT_TMP.invalid_tag_name.err
+
+    # Find invalid tag name
+    cat $OUTPUT_TMP.invalid_tag_name.err | grep -Po 'Invalid tag name: "\K.*?(?=")' > $OUTPUT_TMP.invalid_tag_name
+    
+    # If invalid tag name
+    if (( $(cat $OUTPUT_TMP.invalid_tag_name.err | wc -l) )); then
+
+        # Create tab of invalid tag name and new tag
+        cat $OUTPUT_TMP.invalid_tag_name | awk '
+        {
+            new = $0
+            # Invalid characters "-"
+            gsub("-","_",new)
+            # Start with a digit
+            if (substr(new,1,1) ~ /^[0-9]/ ) {
+                new = "A" new
+            }
+            print "INFO/" $0 "\t" new
+        }
+        ' > $OUTPUT_TMP.invalid_tag_name.tab
+
+        # Rename tag name and annotations
+        $BCFTOOLS annotate --rename-annots $OUTPUT_TMP.invalid_tag_name.tab $OUTPUT_TMP > $OUTPUT_TMP.reformat
+
+        # Move output VCF
+        mv $OUTPUT_TMP.reformat $OUTPUT_TMP
+
+    fi;
+
+fi;
+
+# Final VCF
+if [ "$EXTENSION" == "gz" ]; then
+    bgzip -c $OUTPUT_TMP > $OUTPUT_TMP.compressed
+    mv $OUTPUT_TMP.compressed $OUTPUT_TMP
+fi;
+
+mv $OUTPUT_TMP $VCF_OUTPUT
+
+# Clean
+rm -f $OUTPUT_TMP*
+
+exit 0
+

--- a/config/rules/annotation/howard.rules.mk
+++ b/config/rules/annotation/howard.rules.mk
@@ -31,15 +31,18 @@ HOWARD_NOMEN_FIELDS?="hgvs"
 
 # HOWARD ANNOTATION
 %.howard$(POST_ANNOTATION).vcf: %.vcf %.empty.vcf %.transcripts %.genome
-	# Annotation step DEJAVU
+	# Prevent comma in description in vcf header;
+	$(STARK_FOLDER_BIN)/fix_vcf_header.sh $< $@.tmp0 "$(THREADS_BY_CALLER)" "$(BCFTOOLS)" "$(FIX_VCF_HEADER_REFORMAT)"
+	# Annotation step DEJAVU (deprecated)
 	# +if [ "$(HOWARD_DEJAVU_ANNOTATION)" != "" ]; then \
-	# 	$(HOWARD) $(HOWARD_DEJAVU_CONFIG_OPTIONS) --input=$< --output=$@.tmp0 --annotation=$(HOWARD_DEJAVU_ANNOTATION) --norm=$$(cat $*.genome); \
-	# else \
-	# 	mv $< $@.tmp0; \
+	# 	$(HOWARD) $(HOWARD_DEJAVU_CONFIG_OPTIONS) --input=$@.tmp0 --output=$@.tmp1 --annotation=$(HOWARD_DEJAVU_ANNOTATION) --norm=$$(cat $*.genome); \
+	#	$(STARK_FOLDER_BIN)/fix_vcf_header.sh $@.tmp1 "$(THREADS_BY_CALLER)" "$(BCFTOOLS)"; \
+	#	mv $@.tmp1 $@.tmp0; \
 	# fi;
 	# Annotation calculation step HOWARD
-	#+$(HOWARD) $(HOWARD_CONFIG_OPTIONS) --input=$@.tmp0 --output=$@.tmp --annotation=$(HOWARD_ANNOTATION) --calculation=$(HOWARD_CALCULATION) --transcripts=$*.transcripts --nomen_fields=$(HOWARD_NOMEN_FIELDS) --norm=$$(cat $*.genome);
-	+$(HOWARD) $(HOWARD_CONFIG_OPTIONS) --input=$< --output=$@ --annotation=$(HOWARD_ANNOTATION) --calculation=$(HOWARD_CALCULATION) --transcripts=$*.transcripts --nomen_fields=$(HOWARD_NOMEN_FIELDS) --norm=$$(cat $*.genome);
+	+$(HOWARD) $(HOWARD_CONFIG_OPTIONS) --input=$@.tmp0 --output=$@ --annotation=$(HOWARD_ANNOTATION) --calculation=$(HOWARD_CALCULATION) --transcripts=$*.transcripts --nomen_fields=$(HOWARD_NOMEN_FIELDS) --norm=$$(cat $*.genome);
+	# Prevent comma in description in vcf header
+	$(STARK_FOLDER_BIN)/fix_vcf_header.sh $@ $@ "$(THREADS_BY_CALLER)" "$(BCFTOOLS)" "$(FIX_VCF_HEADER_REFORMAT)"
 	# Clear
 	-if [ ! -e $@ ]; then cp $*.empty.vcf $@; fi;
 	# Downgrading VCF format 4.2 to 4.1

--- a/config/rules/annotation/howard_minimal.rules.mk
+++ b/config/rules/annotation/howard_minimal.rules.mk
@@ -31,12 +31,14 @@ HOWARD_NOMEN_FIELDS?="hgvs"
 
 # HOWARD MINIMAL ANNOTATION
 %.howard_minimal$(POST_ANNOTATION).vcf: %.vcf %.empty.vcf %.transcripts %.genome
+	# Prevent comma in description in vcf header
+	$(STARK_FOLDER_BIN)/fix_vcf_header.sh $< $@.tmp "$(THREADS_BY_CALLER)" "$(BCFTOOLS)" "$(FIX_VCF_HEADER_REFORMAT)"
 	# Annotation step
-	+$(HOWARD) $(HOWARD_CONFIG_OPTIONS) --input=$< --output=$@ --annotation=$(HOWARD_ANNOTATION_MINIMAL) --calculation=$(HOWARD_CALCULATION_MINIMAL) --transcripts=$*.transcripts --nomen_fields=$(HOWARD_NOMEN_FIELDS)  --norm=$$(cat $*.genome);
+	+$(HOWARD) $(HOWARD_CONFIG_OPTIONS) --input=$@.tmp --output=$@ --annotation=$(HOWARD_ANNOTATION_MINIMAL) --calculation=$(HOWARD_CALCULATION_MINIMAL) --transcripts=$*.transcripts --nomen_fields=$(HOWARD_NOMEN_FIELDS)  --norm=$$(cat $*.genome);
 	-if [ ! -e $@ ]; then cp $*.empty.vcf $@; fi;
 	# Downgrading VCF format 4.2 to 4.1
 	-cat $@ | sed "s/##fileformat=VCFv4.2/##fileformat=VCFv4.1/" > $@.dowgrade.4.2.to.4.1.tmp;
-	-rm -f $@;
+	-rm -f $@ $@.tmp*;
 	-mv $@.dowgrade.4.2.to.4.1.tmp $@;
 
 

--- a/config/rules/report.rules.mk
+++ b/config/rules/report.rules.mk
@@ -155,17 +155,26 @@ REPORT_SECTIONS?=ALL
 
 ## FULL VCF: ANNOTATION OF A MERGE FILE
 %.full.vcf: %.merge.vcf %.transcripts %.genome
+	cp $< $@.tmp0
+	# Prevent comma in description in vcf header
+	$(STARK_FOLDER_BIN)/fix_vcf_header.sh $@.tmp0 $@.tmp0  "$(THREADS_BY_SAMPLE)" "$(BCFTOOLS)" "$(FIX_VCF_HEADER_REFORMAT)"
 	# HOWARD annotation
-	+$(HOWARD) $(HOWARD_CONFIG_OPTIONS) --input=$< --output=$@.tmp --annotation=$(HOWARD_ANNOTATION_REPORT) --norm=$$(cat $*.genome);
+	+$(HOWARD) $(HOWARD_CONFIG_OPTIONS) --input=$@.tmp0 --output=$@.tmp1 --annotation=$(HOWARD_ANNOTATION_REPORT) --norm=$$(cat $*.genome);
 	# HOWARD annotation dejavu (forced)
+	# Prevent comma in description in vcf header
+	$(STARK_FOLDER_BIN)/fix_vcf_header.sh $@.tmp1 $@.tmp1 "$(THREADS_BY_SAMPLE)" "$(BCFTOOLS)" "$(FIX_VCF_HEADER_REFORMAT)"
 	+if [ "$(HOWARD_DEJAVU_ANNOTATION)" != "" ]; then \
-		$(HOWARD) $(HOWARD_DEJAVU_CONFIG_OPTIONS) --input=$@.tmp --output=$@.tmp1 --annotation=$(HOWARD_DEJAVU_ANNOTATION) --norm=$$(cat $*.genome) --force; \
+		$(HOWARD) $(HOWARD_DEJAVU_CONFIG_OPTIONS) --input=$@.tmp1 --output=$@.tmp2 --annotation=$(HOWARD_DEJAVU_ANNOTATION) --norm=$$(cat $*.genome) --force; \
 	else \
-		mv $@.tmp $@.tmp1; \
+		mv $@.tmp1 $@.tmp2; \
 	fi;
+	# Prevent comma in description in vcf header
+	$(STARK_FOLDER_BIN)/fix_vcf_header.sh $@.tmp2 $@.tmp2 "$(THREADS_BY_SAMPLE)" "$(BCFTOOLS)" "$(FIX_VCF_HEADER_REFORMAT)"
 	# HOWARD calculation and prioritization
-	+$(HOWARD) $(HOWARD_CONFIG_OPTIONS) --input=$@.tmp1 --output=$@.tmp2 --calculation=$(HOWARD_CALCULATION_REPORT) --nomen_fields=$(HOWARD_NOMEN_FIELDS) --prioritization=$(HOWARD_PRIORITIZATION_REPORT) --transcripts=$*.transcripts --force --norm=$$(cat $*.genome);
-	+$(HOWARD) $(HOWARD_CONFIG_OPTIONS) --input=$@.tmp2 --output=$@ --prioritization=$(HOWARD_PRIORITIZATION_VARANK) --force --norm=$$(cat $*.genome);
+	+$(HOWARD) $(HOWARD_CONFIG_OPTIONS) --input=$@.tmp2 --output=$@.tmp3 --calculation=$(HOWARD_CALCULATION_REPORT) --nomen_fields=$(HOWARD_NOMEN_FIELDS) --prioritization=$(HOWARD_PRIORITIZATION_REPORT) --transcripts=$*.transcripts --force --norm=$$(cat $*.genome);
+	# Prevent comma in description in vcf header
+	$(STARK_FOLDER_BIN)/fix_vcf_header.sh $@.tmp3 $@.tmp3 "$(THREADS_BY_SAMPLE)" "$(BCFTOOLS)" "$(FIX_VCF_HEADER_REFORMAT)"
+	+$(HOWARD) $(HOWARD_CONFIG_OPTIONS) --input=$@.tmp3 --output=$@ --prioritization=$(HOWARD_PRIORITIZATION_VARANK) --force --norm=$$(cat $*.genome);
 	# cleaning
 	rm -rf $@.tmp*
 
@@ -200,16 +209,24 @@ REPORT_SECTIONS?=ALL
 	# List of final VCF files
 	echo $^ | tr " " "\n" | tr "\t" "\n" | grep "final.vcf.gz$$" > $@.tmp.vcf_list
 	$(BCFTOOLS) merge --threads=$(THREADS) -l $@.tmp.vcf_list -m none --force-samples | $(BCFTOOLS) filter --threads=$(THREADS) -S . -e 'GT=="0/0" | GT=="0|0"' > $@.tmp.merged;
+	# Prevent comma in description in vcf header
+	$(STARK_FOLDER_BIN)/fix_vcf_header.sh $@.tmp.merged $@.tmp.merged "$(THREADS_BY_SAMPLE)" "$(BCFTOOLS)" "$(FIX_VCF_HEADER_REFORMAT)";
 	# Annotation
 	+$(HOWARD) $(HOWARD_CONFIG_OPTIONS) --input=$@.tmp.merged --output=$@.tmp.annotated1 --annotation=$(HOWARD_ANNOTATION_ANALYSIS) --threads=$(THREADS);
+	# Prevent comma in description in vcf header
+	$(STARK_FOLDER_BIN)/fix_vcf_header.sh $@.tmp.annotated1 $@.tmp.annotated1 "$(THREADS_BY_SAMPLE)" "$(BCFTOOLS)" "$(FIX_VCF_HEADER_REFORMAT)";
 	# Annotation dejavu (forced)
 	+if [ "$(HOWARD_DEJAVU_ANNOTATION)" != "" ]; then \
-		$(HOWARD) $(HOWARD_DEJAVU_CONFIG_OPTIONS) --input=$@.tmp.annotated1 --output=$@.tmp.annotated --annotation=$(HOWARD_DEJAVU_ANNOTATION) --norm=$$(cat $*.genome) --threads=$(THREADS) --force; \
+		$(HOWARD) $(HOWARD_DEJAVU_CONFIG_OPTIONS) --input=$@.tmp.annotated1 --output=$@.tmp.annotated2 --annotation=$(HOWARD_DEJAVU_ANNOTATION) --norm=$$(cat $*.genome) --threads=$(THREADS) --force; \
 	else \
-		mv $@.tmp.annotated1 $@.tmp.annotated; \
+		mv $@.tmp.annotated1 $@.tmp.annotated2; \
 	fi;
+	# Prevent comma in description in vcf header
+	$(STARK_FOLDER_BIN)/fix_vcf_header.sh $@.tmp.annotated2 $@.tmp.annotated2 "$(THREADS_BY_SAMPLE)" "$(BCFTOOLS)" "$(FIX_VCF_HEADER_REFORMAT)";
 	# Calculation and prioritization (forced)
-	+$(HOWARD) $(HOWARD_CONFIG_OPTIONS) --input=$@.tmp.annotated --output=$@.tmp.calculated.prioritized --calculation=$(HOWARD_CALCULATION_ANALYSIS) --prioritization=$(HOWARD_PRIORITIZATION_ANALYSIS) --nomen_fields=$(HOWARD_NOMEN_FIELDS) --force --threads=$(THREADS);
+	+$(HOWARD) $(HOWARD_CONFIG_OPTIONS) --input=$@.tmp.annotated2 --output=$@.tmp.calculated.prioritized --calculation=$(HOWARD_CALCULATION_ANALYSIS) --prioritization=$(HOWARD_PRIORITIZATION_ANALYSIS) --nomen_fields=$(HOWARD_NOMEN_FIELDS) --force --threads=$(THREADS);
+	# Prevent comma in description in vcf header
+	$(STARK_FOLDER_BIN)/fix_vcf_header.sh $@.tmp.calculated.prioritized $@.tmp.calculated.prioritized "$(THREADS_BY_SAMPLE)" "$(BCFTOOLS)" "$(FIX_VCF_HEADER_REFORMAT)";
 	# Sort VCF
 	mkdir -p $@.tmp.calculated.prioritized.SAMTOOLS_PREFIX
 	$(BCFTOOLS) sort -T $@.tmp.calculated.prioritized.SAMTOOLS_PREFIX $@.tmp.calculated.prioritized > $@.tmp.calculated.prioritized.sorted
@@ -256,16 +273,24 @@ REPORT_SECTIONS?=ALL
 		echo $^ | tr " " "\n" | tr "\t" "\n" | grep "full.vcf.gz$$" > $@.tmp.vcf_list; \
 		for f in $$(cat $@.tmp.vcf_list); do $(BCFTOOLS) view --threads=$(THREADS) -h $$f | grep "^#CHROM" | cut -f10- | sed  "s/^/$$(basename $$f | cut -d. -f1)./g;s/\t/\t$$(basename $$f | cut -d. -f1)./g";  done | tr "\t" "\n" > $@.tmp.vcf_list.pipelines; \
 		$(BCFTOOLS) merge --threads=$(THREADS) -l $@.tmp.vcf_list -m none --force-samples | $(BCFTOOLS) filter --threads=$(THREADS) -S . -e 'GT=="0/0" | GT=="0|0"' | $(BCFTOOLS) reheader --threads=$(THREADS) -s $@.tmp.vcf_list.pipelines > $@.tmp.merged; \
+		# Prevent comma in description in vcf header \
+		$(STARK_FOLDER_BIN)/fix_vcf_header.sh $@.tmp.merged $@.tmp.merged "$(THREADS_BY_SAMPLE)" "$(BCFTOOLS)" "$(FIX_VCF_HEADER_REFORMAT)"; \
 		# Annotation; \
 		$(HOWARD) $(HOWARD_CONFIG_OPTIONS) --input=$@.tmp.merged --output=$@.tmp.annotated0 --annotation=$(HOWARD_ANNOTATION_ANALYSIS) --norm=$$(cat $*.genome) --threads=$(THREADS); \
+		# Prevent comma in description in vcf header \
+		$(STARK_FOLDER_BIN)/fix_vcf_header.sh $@.tmp.annotated0 $@.tmp.annotated0 "$(THREADS_BY_SAMPLE)" "$(BCFTOOLS)" "$(FIX_VCF_HEADER_REFORMAT)"; \
 		# Annotation dejavu (forced); \
 		if [ "$(HOWARD_DEJAVU_ANNOTATION)" != "" ]; then \
-			$(HOWARD) $(HOWARD_DEJAVU_CONFIG_OPTIONS) --input=$@.tmp.annotated0 --output=$@.tmp.annotated --annotation=$(HOWARD_DEJAVU_ANNOTATION) --norm=$$(cat $*.genome) --threads=$(THREADS) --force; \
+			$(HOWARD) $(HOWARD_DEJAVU_CONFIG_OPTIONS) --input=$@.tmp.annotated0 --output=$@.tmp.annotated1 --annotation=$(HOWARD_DEJAVU_ANNOTATION) --norm=$$(cat $*.genome) --threads=$(THREADS) --force; \
 		else \
-			$mv @.tmp.annotated0 $@.tmp.annotated; \
+			mv @.tmp.annotated0 $@.tmp.annotated1; \
 		fi; \
+		# Prevent comma in description in vcf header \
+		$(STARK_FOLDER_BIN)/fix_vcf_header.sh $@.tmp.annotated1 $@.tmp.annotated1 "$(THREADS_BY_SAMPLE)" "$(BCFTOOLS)" "$(FIX_VCF_HEADER_REFORMAT)"; \
 		# Calculation and prioritization (forced); \
-		$(HOWARD) $(HOWARD_CONFIG_OPTIONS) --input=$@.tmp.annotated --output=$@.tmp.calculated.prioritized --calculation=$(HOWARD_CALCULATION_ANALYSIS) --prioritization=$(HOWARD_PRIORITIZATION_ANALYSIS) --nomen_fields=$(HOWARD_NOMEN_FIELDS) --force --threads=$(THREADS); \
+		$(HOWARD) $(HOWARD_CONFIG_OPTIONS) --input=$@.tmp.annotated1 --output=$@.tmp.calculated.prioritized --calculation=$(HOWARD_CALCULATION_ANALYSIS) --prioritization=$(HOWARD_PRIORITIZATION_ANALYSIS) --nomen_fields=$(HOWARD_NOMEN_FIELDS) --force --threads=$(THREADS); \
+		# Prevent comma in description in vcf header \
+		$(STARK_FOLDER_BIN)/fix_vcf_header.sh $@.tmp.calculated.prioritized $@.tmp.calculated.prioritized "$(THREADS_BY_SAMPLE)" "$(BCFTOOLS)" "$(FIX_VCF_HEADER_REFORMAT)"; \
 		# Sort VCF; \
 		mkdir -p $@.tmp.calculated.prioritized.SAMTOOLS_PREFIX; \
 		$(BCFTOOLS) sort -T $@.tmp.calculated.prioritized.SAMTOOLS_PREFIX $@.tmp.calculated.prioritized > $@.tmp.calculated.prioritized.sorted; \


### PR DESCRIPTION
Add fix vcf header script
Remove comma "," in INFO fields Description
Change invalid tag name in VCF (option "FIX_VCF_HEADER_REFORMAT" in APP):
- change "-" to "_" in INFO/IDs (e.g. "PZScore-SOMATIC" to "PZScore_SOMATIC")
- add "A" to INFO/IDs starting by a digit (e.g. "1000g" to "A1000g"